### PR TITLE
Upgrade to wnx/php-swiss-cantons v3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": "^7.4",
     "illuminate/support": "^6.0",
-    "wnx/php-swiss-cantons": "^2.1"
+    "wnx/php-swiss-cantons": "^3.0"
   },
   "require-dev": {
     "codedungeon/phpunit-result-printer": "^0.26.2",

--- a/src/Rules/SwissCantonRule.php
+++ b/src/Rules/SwissCantonRule.php
@@ -109,7 +109,7 @@ class SwissCantonRule implements Rule
 
                 return $canton;
             case self::FORMAT_ZIP_CODE:
-                return $this->getCantonManager()->getByZipcode($value);
+                return $this->getCantonManager()->getByZipcode(intval($value));
             default:
                 throw new InvalidArgumentException(sprintf('The given format "%s" is not valid [%s]', $this->format, implode(', ', self::FORMATS)));
         }


### PR DESCRIPTION
This PR upgrades the package to use the latest version of `wnx/php-swiss-cantons`: [v3.0.0](https://github.com/stefanzweifel/php-swiss-cantons/releases/tag/3.0.0).

The only breaking changes in are dropping support for php 7.2 and php 7.3 (not a concern for this package) and adding types for basically all method.

To make this package compatible with v3.0.0, I had to use `intval()` to cast the value passed to `getByZipcode()` to an integer.