### PR TITLE
Upgrade wnx/php-swiss-cantons to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": "^7.4 || ^8.0",
     "illuminate/contracts": "^6.0 || ^7.0 || ^8.0",
     "illuminate/support": "^6.0 || ^7.0 || ^8.0",
-    "wnx/php-swiss-cantons": "^3.0"
+    "wnx/php-swiss-cantons": "^4.0"
   },
   "require-dev": {
     "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",


### PR DESCRIPTION
The underlying data source has changed and the package got a new major version. The public API remains the same.
More here: https://github.com/stefanzweifel/php-swiss-cantons/releases/tag/4.0.0